### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,9 +6,10 @@
     "3.36",
     "3.38",
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/fthx/workspaces-bar",
   "uuid": "workspaces-bar@fthx",
-  "version": 11
+  "version": 12
 }


### PR DESCRIPTION
Added support for Gnome 42.
Seems to work fine on my system.